### PR TITLE
Added twordle command

### DIFF
--- a/func/getAppOauthFunc.js
+++ b/func/getAppOauthFunc.js
@@ -1,4 +1,4 @@
-import { CLIENT_ID, CLIENT_SECRET} from '../src/constants.js';
+import { CLIENT_ID, CLIENT_SECRET } from '../src/constants.js';
 
 const path = '/oauth2/token?client_id=' + CLIENT_ID + '&client_secret=' + CLIENT_SECRET + '&grant_type=client_credentials';
 const http = require('https');

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
   "author": "Gem",
   "license": "ISC",
   "dependencies": {
-    "@twurple/api": "^5.0.1",
-    "@twurple/auth": "^5.0.1",
-    "@twurple/eventsub": "^5.0.1",
-    "@twurple/eventsub-ngrok": "^5.0.1",
-    "dayjs": "^1.10.6",
+    "@twurple/api": "^5.0.14",
+    "@twurple/auth": "^5.0.14",
+    "@twurple/eventsub": "^5.0.14",
+    "@twurple/eventsub-ngrok": "^5.0.14",
+    "dayjs": "^1.10.7",
     "esm": "^3.2.25",
     "homoglyph-search": "^1.2.1",
-    "tmi.js": "^1.8.3"
+    "tmi.js": "^1.8.5"
   }
 }

--- a/src/_defCommands.js
+++ b/src/_defCommands.js
@@ -206,6 +206,14 @@ export const defCommands = [
     desc: 'Enter a query and try to find the codeword! example: codeword is "test" -> a query of "seat" would give 2 matching places (-e-t) and 1 other matching character (s)'
   },
   {
+    name: 'twordle',
+    run: 'TWORDLE',
+    cd: 5000,
+    cd_default: false,
+    mod: 0,
+    desc: 'A twitch variation of popular game \'Wordle\' words may be longer than 5 letters, attempts are adjusted accordingly. Words are per-username and reset at midnight UTC (GMT)'
+  },
+  {
     name: 'trivia',
     exVar: 'saveChats',
     run: 'TRIVIA_COMMAND',
@@ -221,6 +229,24 @@ export const defCommands = [
     cd_default: false,
     mod: 0,
     desc: 'A tone indicator lookup based on toneindicators and tonetags on carrd co'
+  },
+  {
+    name: 'play',
+    run: function (client, channel) {
+      client.say(channel, '!play');
+    },
+    mod: -1,
+    desc: 'for Marbles streams to allow this bot to play.'
+  },
+  {
+    name: 'so',
+    run: function (client, channel, user, query) {
+      client.say(channel, 'Shout out to ' + query + '! Go give them a follow over at http://twitch.tv/' + query + ' !');
+    },
+    cd: 1000,
+    cd_default: true,
+    mod: 1,
+    desc: 'an alternate shoutout command in case nightbot/bot of choice is down.'
   },
   {
     // banning functions have been moved to ./projectPenguin.js

--- a/src/_tmiChatBot.js
+++ b/src/_tmiChatBot.js
@@ -12,6 +12,7 @@ import { Cooldown } from './cooldown.js';
 import { ProjectPenguin } from './projectPenguin.js';
 import { FISH , FISH_STATS, NB_FISHSTATS } from './fishCommand.js';
 import { CODEWORDGAME } from './codewordsGame.js';
+import { TWORDLE } from './twordle.js';
 import { MORSE, BLOCKLETTER } from './morseDecoder.js';
 import { CONVERT } from './convert.js';
 import { InternetLang } from './ILang.js';
@@ -98,6 +99,7 @@ const functionList = {
   FISH_STATS: FISH_STATS,
   NB_FISHSTATS: NB_FISHSTATS,
   CODEWORDGAME: CODEWORDGAME,
+  TWORDLE: TWORDLE,
   MORSE: MORSE,
   BLOCKLETTER: BLOCKLETTER,
   CONVERT: CONVERT,

--- a/src/filePaths.js
+++ b/src/filePaths.js
@@ -4,6 +4,8 @@ export const files = {
   bannedWords: './data/bannedWords.json',
   fishDataFiles: './data/fishStats.json',
   codewordGameFile: './data/cdewrdFile.json',
+  twordleWordFile: './data/twordle_dictionary.json',
+  twordleDataFile: './data/twordle_data.json',
   triviaCatFile: './data/triviaCat.json',
   triviaData: './data/triviaData.json',
   wordsAPI: './data/wordsAPI.json',

--- a/src/fishCommand.js
+++ b/src/fishCommand.js
@@ -99,7 +99,7 @@ export function FISH_STATS(client, channel, user) {
     let message = "";
     if (fishData.hasOwnProperty(channel) && fishData[channel].hasOwnProperty(YearMonth)){
       fishData = fishData[channel][YearMonth]
-      message = "The !!fish records for this month: largest was " + fishData.maxUser + " with a fish of " + fishData.max.toFixed(2) + 'kg! (' + (fishData.max * 2.20462).toFixed(2) + "lbs) and the smallest was " + fishData.minUser + " with a fish of " + fishData.min.toFixed(2) + 'kg! (' + (fishData.min * 2.20462).toFixed(2) + "lbs)";
+      message = "The !fish records for this month: The largest fish was " + fishData.max.toFixed(2) + 'kg (' + (fishData.max * 2.20462).toFixed(2) + "lbs) caught by " + fishData.maxUser + "! and the smallest fish was " + fishData.min.toFixed(2) + 'kg (' + (fishData.min * 2.20462).toFixed(2) + "lbs) caught by " + fishData.minUser + "!";
     } else {
       message = "The !!fish records have not been set this month...";
     }
@@ -152,7 +152,11 @@ export function NB_FISHSTATS(client, channel, user, query, saveChatArray) {
       }
       if (change) {
         client.say(channel, 'according to my data, that\'s a new record!');
-        gFunc.writeFilePromise(files.fishDataFiles, JSON.stringify(fishData));
+        gFunc.writeFilePromise(files.fishDataFiles, JSON.stringify(fishData)).then( resolve => {
+          // nothing here
+        }, reject => {
+          console.log(gFunc.mkLog('!err', 'ERROR') + 'error writing fish file!');
+        } );
       }
       delete saveChatArray[objName];
     }, 2500);

--- a/src/twordle.js
+++ b/src/twordle.js
@@ -1,0 +1,226 @@
+import fs from 'fs';
+import { files } from './filePaths.js';
+import { gFunc } from './_generalFunctions.js';
+import dayjs from 'dayjs';
+
+// code for twordle game, a twitch adaptation of wordle. reworked from codewordsGame.js (also in src folder).
+export function TWORDLE(client, channel, user, guess) {
+  
+  function findNewWord() {
+    let returnWord;
+    // initialize dictionary
+    try {
+      const data = fs.readFileSync(files.twordleWordFile);
+      returnWord = JSON.parse(data);
+      
+      // return defined here if dictionary exists
+      returnWord = returnWord[Math.floor(Math.random() * returnWord.length)];
+      
+    } catch (err) {
+      // defines a 'first' word as 'first' if no dictionary exists
+      returnWord = 'first';
+      console.log(gFunc.mkLog('info', '%Twordle') + files.twordleWordFile + ' does not exist or cannot be found... making file');
+      try {
+        // create a 'default' twordle dictionary where words are 5-10 letters long
+        const promise = new Promise ((resolve,reject) => {
+          let newData = gFunc.readHttps('https://www.randomlists.com/data/words.json');
+          newData.then( result => {
+            result = JSON.parse(result).data;
+            resolve(result);
+          }, error => {
+            reject(error);
+          })
+        });
+        promise.then( result => {
+          // remove non-eligible words
+          let count = 0;
+          for (let i = 0; i < result.length; i++) {
+            if(result[i].length > 7 || result[i].length < 5 || /[^a-z]/g.test(result[i])) {
+              result.splice(i,1);
+              // we have to re-check this index now
+              i--;
+            }
+          }
+          fs.writeFileSync(files.twordleWordFile, JSON.stringify(result));
+          console.log(gFunc.mkLog('info', '%Twordle') + files.twordleWordFile + ' has been created');
+          
+          // return defined here if dictionary just made
+          returnWord = result[Math.floor(Math.random() * result.length)];
+        }, reject => {
+          console.log(gFunc.mkLog('!err', '%Twordle') + 'could not retrieve default twordle dictionary!');
+        } );      
+      } catch (err) {
+        console.error(err);
+        // if everyone gets 'error' as a word then we know something is up, but game should function and not crash the bot
+        returnWord = 'error';
+      }
+    }
+    return returnWord;
+  }
+  
+  // function for how many attempts allowed based on word length
+  function maxAttempts(wordLen) {
+    return Math.floor(2.5 * (wordLen - 5) + 6);
+  }
+  
+  // fetch user data from twordleDataFile, returns userData object
+  function fetchUserData(twordleData) {
+    const now = new Date();
+    // date in YYYYMMDD
+    const formatDate = now.getUTCFullYear().toString()+(now.getUTCMonth()+1).toString().padStart(2, '0')+now.getUTCDate().toString().padStart(2, '0');
+    // stores word number accross days
+    let wordNum = 1;
+    if (twordleData[user.username]) {
+      if (twordleData[user.username].date === formatDate) {
+        // user file exists and date is still valid
+        return twordleData[user.username];
+      } else {
+        // update wordNum
+        wordNum = twordleData[user.username].wordNum + 1;
+      }
+    }
+    // file doesn't exist or date has changed (return above not triggered)
+    let newWord = findNewWord();
+    // defines a new file
+    return {
+      date: formatDate,
+      word: newWord,
+      wordNum: wordNum,
+      wordLen: newWord.length,
+      attempt: -1,
+      maxAttempt: maxAttempts(newWord.length),
+      prevAttempts: [],
+      prevAttemptSquare: [],
+      complete: false
+    }
+  }
+  
+  // displays stats, returns a string
+  function displayStats(userData) {
+    let returnMsg = 'Guess: ' + userData.attempt + '/' + userData.maxAttempt + ' ';
+    if (userData.attempt === 0) {
+      returnMsg += 'no guesses so far.';
+    } else {
+      returnMsg += 'squares: ';
+      for (let i = 0; i < userData.prevAttemptSquare.length; i++) {
+        returnMsg += userData.prevAttemptSquare[i];
+        returnMsg += ' ';
+      }
+      returnMsg += 'guesses: ';
+      for (let i = 0; i < userData.prevAttempts.length; i++) {
+        returnMsg += userData.prevAttempts[i];
+        returnMsg += ' ';
+      }
+    }
+    return returnMsg;
+  }
+  
+  // handles guesses - updates userData object and returns a message to display
+  function handleGuess(userData, guess){
+    // output message
+    let squares = '';
+    let finMsg = '';
+    let samePlace = 0;
+    for (let i = 0; i < userData.wordLen; i++) {
+      if(guess[i] === userData.word[i]){
+        samePlace++;
+        squares += '🟩';
+      } else {
+        const curSqLen = squares.length;
+        for (let j = 0; j < userData.wordLen; j++) {
+          if (guess[i] === userData.word[j]) {
+            squares += '🟨';
+            break;
+          }
+        }
+        // incorrect letter
+        if (squares.length === curSqLen) {
+          squares += '⬛';
+        }
+      }
+    }
+
+    if(samePlace === userData.wordLen){
+      // they got it right
+      userData.complete = true;
+      finMsg = ' Congrats! you got it!';
+    }
+    // update attempts
+    userData.attempt++;
+    // update arrays
+    userData.prevAttempts.push(guess);
+    userData.prevAttemptSquare.push(squares);
+    // update complete from reachign attempt limit
+    if (userData.attempt === userData.maxAttempt) {
+      userData.complete = true;
+      finMsg = ' the word was ' + userData.word;
+    }
+    return 'Attempt ' + userData.attempt + '/' + userData.maxAttempt + ': ' + squares + finMsg;
+  }
+  
+  // 'run' starts here
+  guess = guess.replace(/\s/,'');
+  guess = guess.toLowerCase();
+  guess = guess.split();
+  
+  // data file object
+  let twordleData;
+  
+  // open twordleDataFile
+  try {
+    twordleData = JSON.parse(fs.readFileSync(files.twordleDataFile));
+    // file exists, check for user file
+
+  } catch (err) {
+    console.log(gFunc.mkLog('info', '%Twordle') + files.twordleDataFile + ' does not exist or cannot be found... making file');
+    twordleData = {};
+    fs.writeFileSync(files.twordleDataFile, '{}');
+    console.log(gFunc.mkLog('info', '%Twordle') + files.twordleDataFile + ' has been created');
+  }
+  
+  // data for specific user
+  let userData = fetchUserData(twordleData);
+  // debug: console.log(userData);
+  
+  // location for special queries (empty for now)
+  
+  // if it's a new word, display data, don't let them continue
+  if (userData.attempt === -1) {
+    const endMsg = ' Your word for today is ' + userData.wordLen + ' letters long. You have ' + userData.maxAttempt + ' attempts.'
+    if (userData.wordNum === 1) {
+      // first twordle
+      const startMsg = 'Hi, ' + user['display-name'] + ', welcome to twordle, a twitch adaptation of Wordle!';
+      client.say(channel, startMsg + endMsg);
+    } else {
+      const startMsg = 'New day, new word, ' + user['display-name'] + '.';
+      client.say(channel, startMsg + endMsg);
+    }
+    userData.attempt++;
+  } else if (userData.complete) {
+    // they are done for today
+    const now = new Date();
+    const timeToNext = (23 - now.getUTCHours()).toString() + 'h ' + (59 - now.getUTCMinutes()).toString() + 'm';
+    client.say(channel, 'Final stats for ' + user['display-name'] + ' today: ' + displayStats(userData) + '. Next twordle in approx. ' + timeToNext);    
+  } else {
+    // query options
+    if(guess[0].length === 0){
+      // display current data
+      client.say(channel, 'Stats so far for ' + user['display-name'] + ' ' + displayStats(userData));
+    } else if (guess[0].length !== userData.wordLen) {
+      client.say(channel, 'Your guess doesn\'t match the world length! alternatively, for current stats, leave the query blank');
+    } else {
+      const msg = handleGuess(userData, guess[0]);
+      client.say(channel, msg);
+    }
+  }
+  
+  // save current round
+  twordleData[user.username] = userData;
+  try {
+    fs.writeFileSync(files.twordleDataFile, JSON.stringify(twordleData));
+  } catch (err) {
+    console.err(err);
+    // output what was supposed to save if failed
+    console.log(userData);
+  }
+}

--- a/src/twordle.js
+++ b/src/twordle.js
@@ -91,6 +91,7 @@ export function TWORDLE(client, channel, user, query) {
       maxAttempt: maxAttempts(newWord.length),
       prevAttempts: [],
       prevAttemptSquare: [],
+      wrongLetters: [],
       complete: false
     }
   }
@@ -104,17 +105,13 @@ export function TWORDLE(client, channel, user, query) {
       // to not clutter chat as much, guesses only shown on request
       if (showGuesses) {
         returnMsg += 'guesses: ';
-        for (let i = 0; i < userData.prevAttempts.length; i++) {
-          returnMsg += userData.prevAttempts[i];
-          returnMsg += ' ';
-        }
+        returnMsg += userData.prevAttempts.join(', ');
+        returnMsg += ' | your word does not contain: ';
+        returnMsg += userData.wrongLetters.join(', ');
       } else {
         returnMsg += 'squares: ';
-        for (let i = 0; i < userData.prevAttemptSquare.length; i++) {
-          returnMsg += userData.prevAttemptSquare[i];
-          returnMsg += ' ';
-        }
-        returnMsg += 'use \'show\' for guesses';
+        returnMsg += userData.prevAttemptSquare.join(', ');
+        returnMsg += ' use \'show\' for guesses and wrong letters';
       }
     }
     return returnMsg;
@@ -141,6 +138,9 @@ export function TWORDLE(client, channel, user, query) {
         // incorrect letter
         if (squares.length === curSqLen) {
           squares += '⬛';
+          if (!userData.wrongLetters.includes(guess[i])) {
+            userData.wrongLetters.push(guess[i]);
+          }
         }
       }
     }
@@ -218,6 +218,8 @@ export function TWORDLE(client, channel, user, query) {
     } else if (query[0].length !== userData.wordLen) {
       if (query[0] === 'show') {
         client.say(channel, 'Stats so far for ' + user['display-name'] + ' ' + displayStats(userData, true));
+      } else if(query[0] === '!') {
+        client.say(channel, user['display-name'] + ', your word does NOT contain: ' + userData.wrongLetters.join(', '));
       } else {
         client.say(channel, 'Your guess doesn\'t match the world length! alternatively, for current stats, leave the query blank, or \'show\' for previous guesses');
       }

--- a/src/twordle.js
+++ b/src/twordle.js
@@ -60,7 +60,7 @@ export function TWORDLE(client, channel, user, query) {
   
   // function for how many attempts allowed based on word length
   function maxAttempts(wordLen) {
-    return Math.floor(2.5 * (wordLen - 5) + 6);
+    return Math.floor(2 * (wordLen - 5) + 6);
   }
   
   // fetch user data from twordleDataFile, returns userData object
@@ -106,12 +106,17 @@ export function TWORDLE(client, channel, user, query) {
       if (showGuesses) {
         returnMsg += 'guesses: ';
         returnMsg += userData.prevAttempts.join(', ');
-        returnMsg += ' | your word does not contain: ';
-        returnMsg += userData.wrongLetters.join(', ');
+        if (!userData.complete) {
+          returnMsg += ' | your word does not contain: ';
+          returnMsg += userData.wrongLetters.join(', ');
+        }
       } else {
         returnMsg += 'squares: ';
-        returnMsg += userData.prevAttemptSquare.join(', ');
-        returnMsg += ' use \'show\' for guesses and wrong letters';
+        returnMsg += userData.prevAttemptSquare.join(' ');
+        returnMsg += ' use \'show\' for guesses';
+        if (!userData.complete) {
+          returnMsg += ' and wrong letters';
+        }
       }
     }
     return returnMsg;
@@ -156,7 +161,7 @@ export function TWORDLE(client, channel, user, query) {
     userData.prevAttempts.push(guess);
     userData.prevAttemptSquare.push(squares);
     // update complete from reachign attempt limit
-    if (userData.attempt === userData.maxAttempt) {
+    if (userData.attempt === userData.maxAttempt && !userData.complete) {
       userData.complete = true;
       finMsg = ' the word was ' + userData.word;
     }


### PR DESCRIPTION
Added twordle, a twitch chat adaptation of wordle.
Using '!!' as the prefix:

`!!twordle help` still overrides to a command-level guide that describes what this command does

If user has not been given a word today
`!!twordle` gives them a word by looking at an internal dictionary.
if no dictionary exists. one is created from https://www.randomlists.com/data/words.json and automatically filtered for 5-7 letter long words.

If a game HAS started and user has NOT completed:
| query | executes |
| --- | --- |
| _[blank]_ | 'squares' interface is shown with a message to see what guesses user has made and other info |
| show | shows user's current guesses and letters previously used and not present in their word |
| ! | shows ONLY what letters previously used and not present in their word |
| _[guess with right amount of letters]_ | evaluates the guess and outputs squares according to 'wordle' rules |
| _[guess with wrong amount of letters]_ | tells user their guess doesn't match their word length, and some other possible queries |

If user has completed their twordle for the day:
| query | executes |
| --- | --- |
| show | shows user's guesses |
| _[anything else]_ | 'squares' interface is shown with a message to see what guesses user has made |
